### PR TITLE
Implements basic with_side_effect on GraphTraversalSource

### DIFF
--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -62,7 +62,7 @@ mod pool;
 
 pub use client::GremlinClient;
 pub use connection::{ConnectionOptions, TlsOptions};
-pub use conversion::{BorrowFromGValue, ToGValue};
+pub use conversion::{BorrowFromGValue, ToGValue, FromGValue};
 pub use error::GremlinError;
 
 pub type GremlinResult<T> = Result<T, error::GremlinError>;

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -62,7 +62,7 @@ mod pool;
 
 pub use client::GremlinClient;
 pub use connection::{ConnectionOptions, TlsOptions};
-pub use conversion::{BorrowFromGValue, ToGValue, FromGValue};
+pub use conversion::{BorrowFromGValue, FromGValue, ToGValue};
 pub use error::GremlinError;
 
 pub type GremlinResult<T> = Result<T, error::GremlinError>;

--- a/gremlin-client/src/process/traversal/graph_traversal_source.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal_source.rs
@@ -1,4 +1,4 @@
-use crate::conversion::ToGValue;
+use crate::conversion::{FromGValue, ToGValue};
 use crate::process::traversal::strategies::{
     RemoteStrategy, TraversalStrategies, TraversalStrategy,
 };
@@ -89,6 +89,20 @@ impl<A: Terminator<GValue>> GraphTraversalSource<A> {
             ids.into().0.iter().map(|id| id.to_gvalue()).collect(),
         );
 
+        GraphTraversal::new(self.term.clone(), TraversalBuilder::new(code))
+    }
+
+    pub fn with_side_effect<T>(&self, step: (&'static str, T)) -> GraphTraversal<GValue, GValue, A>
+    where
+        T: Into<GValue> + FromGValue,
+        A: Terminator<T>,
+    {
+        let mut code = Bytecode::new();
+
+        code.add_source(
+            String::from("withSideEffect"),
+            vec![step.0.into(), step.1.into()],
+        );
         GraphTraversal::new(self.term.clone(), TraversalBuilder::new(code))
     }
 }


### PR DESCRIPTION
This PR makes the `withSideEffect` functionality possible. This can be used on Neptune do stuff such as: https://docs.aws.amazon.com/neptune/latest/userguide/gremlin-query-hints-repeatMode.html. 

I couldn't figure out what kind of test to write that would work against a normal Tinkerpop server. I have tested this against Neptune and all works well. I can see uses of the function in the Tinkerpop documentation but the other methods in order to implement them are not implemented in gremlin-rs. (see: http://tinkerpop.apache.org/docs/current/reference/#where-step).

FromGValue also made public so that user made functions can be created with generic trait parameter `E: FromGValue` for passing around `GraphTraversal`. 

