### PR TITLE
Added sending property cardinality with two new functions

### DIFF
--- a/gremlin-client/src/io/mod.rs
+++ b/gremlin-client/src/io/mod.rs
@@ -4,7 +4,7 @@ mod serializer_v3;
 
 use crate::conversion::ToGValue;
 use crate::process::traversal::{Order, Scope};
-use crate::structure::{GValue, T};
+use crate::structure::{Cardinality, GValue, T};
 use serde_json::{json, Value};
 use std::string::ToString;
 
@@ -173,6 +173,19 @@ impl GraphSON {
                 "@type": "g:Pop",
                 "@value": *pop.to_string(),
             })),
+
+            GValue::Cardinality(cardinality) => {
+                let v = match cardinality {
+                    Cardinality::List => "list",
+                    Cardinality::Single => "single",
+                    Cardinality::Set => "set",
+                };
+
+                Ok(json!({
+                    "@type" : "g:Cardinality",
+                    "@value" : v
+                }))
+            }
 
             _ => panic!("Type {:?} not supported.", value),
         }

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -127,8 +127,8 @@ pub use error::GremlinError;
 pub type GremlinResult<T> = Result<T, error::GremlinError>;
 
 pub use structure::{
-    Edge, GKey, GResultSet, GValue, IntermediateRepr, List, Map, Metric, Path, Property, Token,
-    TraversalExplanation, TraversalMetrics, Vertex, VertexProperty, GID,
+    Cardinality, Edge, GKey, GResultSet, GValue, IntermediateRepr, List, Map, Metric, Path,
+    Property, Token, TraversalExplanation, TraversalMetrics, Vertex, VertexProperty, GID,
 };
 
 #[cfg(feature = "async_gremlin")]

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -16,7 +16,7 @@ use crate::process::traversal::step::until::IntoUntilStep;
 use crate::process::traversal::step::where_step::IntoWhereStep;
 
 use crate::process::traversal::{Bytecode, Scope};
-use crate::structure::Labels;
+use crate::structure::{Cardinality, Labels};
 use crate::{structure::GIDs, structure::IntoPredicate, GValue};
 
 #[derive(Clone)]
@@ -81,6 +81,22 @@ impl TraversalBuilder {
         self.bytecode.add_step(
             String::from("property"),
             vec![String::from(key).into(), value.into()],
+        );
+        self
+    }
+
+    pub fn property_with_cardinality<A>(
+        mut self,
+        cardinality: Cardinality,
+        key: &str,
+        value: A,
+    ) -> Self
+    where
+        A: Into<GValue>,
+    {
+        self.bytecode.add_step(
+            String::from("property"),
+            vec![cardinality.into(), String::from(key).into(), value.into()],
         );
         self
     }

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -17,7 +17,7 @@ use crate::process::traversal::step::where_step::IntoWhereStep;
 
 use crate::process::traversal::remote::Terminator;
 use crate::process::traversal::{Bytecode, Scope, TraversalBuilder};
-use crate::structure::Labels;
+use crate::structure::{Cardinality, Labels};
 use crate::{
     structure::GIDs, structure::GProperty, structure::IntoPredicate, Edge, GValue, List, Map, Path,
     Vertex,
@@ -71,12 +71,43 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         self
     }
 
+    pub fn property_with_cardinality<A>(
+        mut self,
+        cardinality: Cardinality,
+        key: &str,
+        value: A,
+    ) -> Self
+    where
+        A: Into<GValue>,
+    {
+        self.builder = self
+            .builder
+            .property_with_cardinality(cardinality, key, value);
+        self
+    }
+
     pub fn property_many<A>(mut self, values: Vec<(String, A)>) -> Self
     where
         A: Into<GValue>,
     {
         for property in values {
             self.builder = self.builder.property(property.0.as_ref(), property.1)
+        }
+
+        self
+    }
+
+    pub fn property_many_with_cardinality<A>(
+        mut self,
+        values: Vec<(Cardinality, String, A)>,
+    ) -> Self
+    where
+        A: Into<GValue>,
+    {
+        for property in values {
+            self.builder =
+                self.builder
+                    .property_with_cardinality(property.0, property.1.as_ref(), property.2);
         }
 
         self

--- a/gremlin-client/src/structure/cardinality.rs
+++ b/gremlin-client/src/structure/cardinality.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, PartialEq, Clone)]
+pub enum Cardinality {
+    List,
+    Set,
+    Single,
+}

--- a/gremlin-client/src/structure/label.rs
+++ b/gremlin-client/src/structure/label.rs
@@ -45,6 +45,14 @@ impl Into<Labels> for bool {
     }
 }
 
+impl Into<Labels> for (bool, Vec<&str>) {
+    fn into(self) -> Labels {
+        let mut out: Vec<LabelType> = vec![LabelType::Bool(self.0)];
+        out.append(&mut Into::<Labels>::into(self.1).0.drain(..).collect());
+        Labels(out)
+    }
+}
+
 macro_rules! impl_into_labels_str {
     ($n:expr) => {
         impl Into<Labels> for [&str; $n] {

--- a/gremlin-client/src/structure/mod.rs
+++ b/gremlin-client/src/structure/mod.rs
@@ -1,3 +1,4 @@
+mod cardinality;
 mod edge;
 mod either;
 mod gid;
@@ -32,6 +33,7 @@ pub use self::token::Token;
 pub use self::value::GValue;
 pub use self::vertex::Vertex;
 pub use self::vertex_property::{GProperty, VertexProperty};
+pub use cardinality::Cardinality;
 pub use either::*;
 pub use label::Labels;
 pub use map::{GKey, Map};

--- a/gremlin-client/src/structure/value.rs
+++ b/gremlin-client/src/structure/value.rs
@@ -2,8 +2,8 @@ use crate::conversion::{BorrowFromGValue, FromGValue};
 use crate::process::traversal::{Bytecode, Order, Scope};
 use crate::structure::traverser::Traverser;
 use crate::structure::{
-    label::LabelType, Edge, GKey, IntermediateRepr, List, Map, Metric, Path, Property, Set, Token,
-    TraversalExplanation, TraversalMetrics, Vertex, VertexProperty,
+    label::LabelType, Cardinality, Edge, GKey, IntermediateRepr, List, Map, Metric, Path, Property,
+    Set, Token, TraversalExplanation, TraversalMetrics, Vertex, VertexProperty,
 };
 use crate::structure::{Pop, TextP, P, T};
 use crate::GremlinResult;
@@ -44,6 +44,7 @@ pub enum GValue {
     Bool(bool),
     TextP(TextP),
     Pop(Pop),
+    Cardinality(Cardinality),
 }
 
 impl GValue {
@@ -271,5 +272,11 @@ impl From<LabelType> for GValue {
             LabelType::Str(val) => val.into(),
             LabelType::Bool(val) => val.into(),
         }
+    }
+}
+
+impl From<Cardinality> for GValue {
+    fn from(val: Cardinality) -> GValue {
+        GValue::Cardinality(val)
     }
 }


### PR DESCRIPTION
Added two new functions on GraphTraversal - `property_with_cardinality()` and `property_many_with_cardinality()`. 

I wanted to implement cardinality on new functions as otherwise the `.property()` input would have to be converted into a tuple. Meaning all existing implementation of `.property()` made by people would have to be migrated over to use tuples.

If you would prefer to implement this within .property I can do that instead - just let me know.