### PR TITLE
Some more features

### DIFF
--- a/gremlin-client/src/aio/client.rs
+++ b/gremlin-client/src/aio/client.rs
@@ -94,7 +94,6 @@ impl GremlinClient {
         };
 
         let conn = self.pool.get().await?;
-
         self.send_message_new(conn, message).await
     }
 
@@ -126,7 +125,6 @@ impl GremlinClient {
                         .read(&response.result.data)?
                         .map(|v| v.into())
                         .unwrap_or_else(VecDeque::new);
-
                     Ok((response, results))
                 }
                 204 => Ok((response, VecDeque::new())),

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -110,6 +110,8 @@
 //!    })
 //!}
 //!
+#[macro_use]
+extern crate lazy_static;
 
 mod client;
 mod connection;

--- a/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
+++ b/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
@@ -167,6 +167,20 @@ impl AnonymousTraversalSource {
     pub fn cap(&self, step: &'static str) -> TraversalBuilder {
         self.traversal.clone().cap(step)
     }
+
+    pub fn project<A>(&self, step: A) ->TraversalBuilder
+    where
+        A: IntoSelectStep,
+    {
+        self.traversal.clone().project(step)
+    }
+
+    pub fn constant<A>(&self, value: A) -> TraversalBuilder
+    where
+        A: Into<GValue>,
+    {
+        self.traversal.clone().constant(value)
+    }
 }
 
 impl Default for AnonymousTraversalSource {

--- a/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
+++ b/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
@@ -5,7 +5,7 @@ use crate::process::traversal::step::or::OrStep;
 use crate::process::traversal::step::select::SelectStep;
 use crate::process::traversal::step::where_step::WhereStep;
 use crate::process::traversal::TraversalBuilder;
-use crate::structure::{GIDs, IntoPredicate, Labels};
+use crate::structure::{Either2, GIDs, IntoPredicate, Labels, T};
 use crate::GValue;
 
 pub struct AnonymousTraversalSource {
@@ -37,7 +37,7 @@ impl AnonymousTraversalSource {
         self.traversal.clone().add_v(label)
     }
 
-    pub fn property<A>(&self, key: &str, value: A) -> TraversalBuilder
+    pub fn property<A>(&self, key: Either2<&str, T>, value: A) -> TraversalBuilder
     where
         A: Into<GValue>,
     {
@@ -168,7 +168,7 @@ impl AnonymousTraversalSource {
         self.traversal.clone().cap(step)
     }
 
-    pub fn project<A>(&self, step: A) ->TraversalBuilder
+    pub fn project<A>(&self, step: A) -> TraversalBuilder
     where
         A: IntoSelectStep,
     {

--- a/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
+++ b/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
@@ -170,7 +170,7 @@ impl AnonymousTraversalSource {
 
     pub fn project<A>(&self, step: A) -> TraversalBuilder
     where
-        A: Into<SelectStep>
+        A: Into<SelectStep>,
     {
         self.traversal.clone().project(step)
     }

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -585,4 +585,15 @@ impl TraversalBuilder {
         self.bytecode.add_step(String::from("optional"), vec![step.bytecode.into()]);
         self
     }
+
+    pub fn constant<A>(mut self, value: A) -> Self
+    where
+        A: Into<GValue>,
+    {
+        self.bytecode.add_step(
+            String::from("constant"),
+            vec![value.into()],
+        );
+        self
+    }
 }

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -18,8 +18,8 @@ use crate::process::traversal::step::until::UntilStep;
 use crate::process::traversal::step::where_step::WhereStep;
 
 use crate::process::traversal::{Bytecode, Scope};
-use crate::structure::{Cardinality, Labels};
-use crate::{structure::GIDs, structure::IntoPredicate, GValue};
+use crate::structure::{Cardinality, Either2, GIDs, IntoPredicate, Labels, T};
+use crate::GValue;
 
 #[derive(Clone)]
 pub struct TraversalBuilder {
@@ -76,14 +76,12 @@ impl TraversalBuilder {
         self
     }
 
-    pub fn property<A>(mut self, key: &str, value: A) -> Self
+    pub fn property<A>(mut self, key: Either2<&str, T>, value: A) -> Self
     where
         A: Into<GValue>,
     {
-        self.bytecode.add_step(
-            String::from("property"),
-            vec![String::from(key).into(), value.into()],
-        );
+        self.bytecode
+            .add_step(String::from("property"), vec![key.into(), value.into()]);
         self
     }
 
@@ -582,7 +580,8 @@ impl TraversalBuilder {
     }
 
     pub fn optional(mut self, step: TraversalBuilder) -> Self {
-        self.bytecode.add_step(String::from("optional"), vec![step.bytecode.into()]);
+        self.bytecode
+            .add_step(String::from("optional"), vec![step.bytecode.into()]);
         self
     }
 
@@ -590,10 +589,8 @@ impl TraversalBuilder {
     where
         A: Into<GValue>,
     {
-        self.bytecode.add_step(
-            String::from("constant"),
-            vec![value.into()],
-        );
+        self.bytecode
+            .add_step(String::from("constant"), vec![value.into()]);
         self
     }
 }

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -575,4 +575,14 @@ impl TraversalBuilder {
             .add_step(String::from("cap"), vec![step.into()]);
         self
     }
+
+    pub fn barrier(mut self) -> Self {
+        self.bytecode.add_step(String::from("barrier"), vec![]);
+        self
+    }
+
+    pub fn optional(mut self, step: TraversalBuilder) -> Self {
+        self.bytecode.add_step(String::from("optional"), vec![step.bytecode.into()]);
+        self
+    }
 }

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -18,7 +18,7 @@ use crate::process::traversal::step::until::UntilStep;
 use crate::process::traversal::step::where_step::WhereStep;
 
 use crate::process::traversal::{Bytecode, Scope};
-use crate::structure::{Cardinality, Either2, GIDs, IntoPredicate, Labels, T};
+use crate::structure::{Cardinality, GIDs, IntoPredicate, Labels};
 use crate::GValue;
 
 #[derive(Clone)]
@@ -76,8 +76,9 @@ impl TraversalBuilder {
         self
     }
 
-    pub fn property<A>(mut self, key: Either2<&str, T>, value: A) -> Self
+    pub fn property<K, A>(mut self, key: K, value: A) -> Self
     where
+        K: Into<GValue>,
         A: Into<GValue>,
     {
         self.bytecode

--- a/gremlin-client/src/process/traversal/bytecode.rs
+++ b/gremlin-client/src/process/traversal/bytecode.rs
@@ -34,7 +34,8 @@ impl Bytecode {
 }
 
 lazy_static! {
-    pub static ref WRITE_OPERATORS: Vec<&'static str> = vec!["addV", "property", "addE", "from", "to", "drop"];
+    pub static ref WRITE_OPERATORS: Vec<&'static str> =
+        vec!["addV", "property", "addE", "from", "to", "drop"];
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/gremlin-client/src/process/traversal/bytecode.rs
+++ b/gremlin-client/src/process/traversal/bytecode.rs
@@ -33,6 +33,10 @@ impl Bytecode {
     }
 }
 
+lazy_static! {
+    pub static ref WRITE_OPERATORS: Vec<&'static str> = vec!["addV", "property", "addE", "from", "to", "drop"];
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Instruction {
     operator: String,

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -622,4 +622,14 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         self.builder = self.builder.cap(step);
         self
     }
+
+    pub fn barrier(mut self) -> Self {
+        self.builder = self.builder.barrier();
+        self
+    }
+
+    pub fn optional(mut self, step: TraversalBuilder) -> Self {
+        self.builder = self.builder.optional(step);
+        self
+    }
 }

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -632,4 +632,13 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         self.builder = self.builder.optional(step);
         self
     }
+
+    pub fn constant<A>(mut self, value: A) -> Self
+    where
+        A: Into<GValue>,
+    {
+        self.builder = self.builder.constant(value);
+        self
+    }
+
 }

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -22,7 +22,7 @@ use crate::process::traversal::strategies::{
     RemoteStrategy, TraversalStrategies, TraversalStrategy,
 };
 use crate::process::traversal::{Bytecode, Scope, TraversalBuilder, WRITE_OPERATORS};
-use crate::structure::{Cardinality, Labels, T as TValue};
+use crate::structure::{Cardinality, Labels};
 use crate::{
     structure::GIDs, structure::GProperty, structure::IntoPredicate, Edge, GValue, GremlinClient,
     List, Map, Path, Vertex,
@@ -90,14 +90,6 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
     }
 
     pub fn property<A>(mut self, key: &str, value: A) -> Self
-    where
-        A: Into<GValue>,
-    {
-        self.builder = self.builder.property(key, value);
-        self
-    }
-
-    pub fn property_for_id<A>(mut self, key: TValue, value: A) -> Self
     where
         A: Into<GValue>,
     {

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -22,7 +22,7 @@ use crate::process::traversal::strategies::{
     RemoteStrategy, TraversalStrategies, TraversalStrategy,
 };
 use crate::process::traversal::{Bytecode, Scope, TraversalBuilder, WRITE_OPERATORS};
-use crate::structure::{Cardinality, Either2, Labels, T as TValue};
+use crate::structure::{Cardinality, Labels, T as TValue};
 use crate::{
     structure::GIDs, structure::GProperty, structure::IntoPredicate, Edge, GValue, GremlinClient,
     List, Map, Path, Vertex,
@@ -89,7 +89,15 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         GraphTraversal::new(self.terminator, self.builder)
     }
 
-    pub fn property<A>(mut self, key: Either2<&str, TValue>, value: A) -> Self
+    pub fn property<A>(mut self, key: &str, value: A) -> Self
+    where
+        A: Into<GValue>,
+    {
+        self.builder = self.builder.property(key, value);
+        self
+    }
+
+    pub fn property_for_id<A>(mut self, key: TValue, value: A) -> Self
     where
         A: Into<GValue>,
     {
@@ -119,7 +127,7 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         for property in values {
             self.builder = self
                 .builder
-                .property(Either2::A(property.0.as_ref()), property.1)
+                .property::<&str, A>(property.0.as_ref(), property.1)
         }
 
         self

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -17,15 +17,15 @@ use crate::process::traversal::step::to::ToStep;
 use crate::process::traversal::step::until::UntilStep;
 use crate::process::traversal::step::where_step::WhereStep;
 
-use crate::process::traversal::remote::{Terminator, SyncTerminator};
-use crate::process::traversal::{Bytecode, Scope, TraversalBuilder, WRITE_OPERATORS};
+use crate::process::traversal::remote::{SyncTerminator, Terminator};
 use crate::process::traversal::strategies::{
     RemoteStrategy, TraversalStrategies, TraversalStrategy,
 };
-use crate::structure::{Cardinality, Labels};
+use crate::process::traversal::{Bytecode, Scope, TraversalBuilder, WRITE_OPERATORS};
+use crate::structure::{Cardinality, Either2, Labels, T as TValue};
 use crate::{
-    structure::GIDs, structure::GProperty, structure::IntoPredicate, Edge, GValue, List, Map, Path,
-    Vertex, GremlinClient
+    structure::GIDs, structure::GProperty, structure::IntoPredicate, Edge, GValue, GremlinClient,
+    List, Map, Path, Vertex,
 };
 use std::marker::PhantomData;
 
@@ -56,12 +56,15 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
             start: self.start,
             end: self.end,
             builder: self.builder,
-            terminator: SyncTerminator::new(strategies)
+            terminator: SyncTerminator::new(strategies),
         }
     }
 
     pub fn does_write(&self) -> bool {
-        self.bytecode().steps().iter().any(|instruction| WRITE_OPERATORS.contains(&&*instruction.operator().as_ref()))
+        self.bytecode()
+            .steps()
+            .iter()
+            .any(|instruction| WRITE_OPERATORS.contains(&&*instruction.operator().as_ref()))
     }
 
     pub fn bytecode(&self) -> &Bytecode {
@@ -86,7 +89,7 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         GraphTraversal::new(self.terminator, self.builder)
     }
 
-    pub fn property<A>(mut self, key: &str, value: A) -> Self
+    pub fn property<A>(mut self, key: Either2<&str, TValue>, value: A) -> Self
     where
         A: Into<GValue>,
     {
@@ -114,7 +117,9 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         A: Into<GValue>,
     {
         for property in values {
-            self.builder = self.builder.property(property.0.as_ref(), property.1)
+            self.builder = self
+                .builder
+                .property(Either2::A(property.0.as_ref()), property.1)
         }
 
         self
@@ -640,5 +645,4 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         self.builder = self.builder.constant(value);
         self
     }
-
 }

--- a/gremlin-client/src/process/traversal/mod.rs
+++ b/gremlin-client/src/process/traversal/mod.rs
@@ -18,7 +18,7 @@ pub use order::Order;
 pub use remote::{traversal, SyncTerminator, Terminator};
 
 pub use builder::TraversalBuilder;
-pub use bytecode::Bytecode;
+pub use bytecode::{Bytecode, WRITE_OPERATORS};
 pub use graph_traversal::GraphTraversal;
 pub use graph_traversal_source::GraphTraversalSource;
 pub use scope::Scope;

--- a/gremlin-client/src/process/traversal/remote.rs
+++ b/gremlin-client/src/process/traversal/remote.rs
@@ -18,6 +18,10 @@ impl RemoteTraversalSource {
         GraphTraversalSource::<MockTerminator>::new(MockTerminator {}).with_remote(client)
     }
 
+    pub fn empty(&self) -> GraphTraversalSource<MockTerminator> {
+        GraphTraversalSource::<MockTerminator>::new(MockTerminator {})
+    }
+
     #[cfg(feature = "async_gremlin")]
     pub fn with_remote_async(
         &self,

--- a/gremlin-client/src/structure/either.rs
+++ b/gremlin-client/src/structure/either.rs
@@ -1,4 +1,4 @@
-use crate::structure::{GValue, Vertex};
+use crate::structure::{GValue, Vertex, T};
 
 pub enum Either2<A: Into<GValue>, B: Into<GValue>> {
     A(A),
@@ -21,6 +21,18 @@ where
             Either2::A(a) => a.into(),
             Either2::B(b) => b.into(),
         }
+    }
+}
+
+impl From<&str> for Either2<String, T> {
+    fn from(val: &str) -> Self {
+        Either2::A(String::from(val))
+    }
+}
+
+impl From<T> for Either2<String, T> {
+    fn from(val: T) -> Self {
+        Either2::B(val)
     }
 }
 


### PR DESCRIPTION
This PR implements the following:

- `.project()`,  `.constant()` & `.barrier()` steps on Traversal's
- New `.empty()` on `RemoteTraversalSource` allows for init and building of traversal before deciding which remote to send requests to
- `.does_write()` method on `GraphTraversal`. Allows for determining if a traversal does some write operation and then sending to a gremlin server which is used for write operations. This is handy in AWS Neptune where you have one write database and the possibility of several read replicas.
- New `.changeRemote()` method on `GraphTraversal`

Sorry no tests yet, but all methods are operating as expected in my application
