### PR TITLE
Closes #97.

### DIFF
--- a/gremlin-client/src/io/macros.rs
+++ b/gremlin-client/src/io/macros.rs
@@ -3,6 +3,8 @@ macro_rules! g_serializer {
         pub fn $name(val: &Value) -> GremlinResult<GValue> {
             if let Value::String(ref s) = val {
                 Ok(s.clone().into())
+            } else if let Value::Bool(b) = val {
+                Ok((*b).into())
             } else {
                 let _type = &val["@type"];
                 let _type = get_value!(_type,serde_json::Value::String)?.as_str();


### PR DESCRIPTION
This change should close #97.  It looks like the problem was in the deserialization path. The query was returning a vertex property with a boolean property.  Or rather more, precisely, property that was a g:List of booleans. The deserializer was correctly identifying the list and passing it to deserialize_list, which then called reader on the first and only element of the list, which was a serialized boolean. The g_serializer macro was unequipped to handle a boolean result, though.

Admittedly, what I don't understand is why the Gremlin server was passing back the property value in the array as a straight serialized boolean.  When I make the same query passing an integer instead of a boolean, it comes back as an object in the array, with a type and value separately:

```
Object({
                                    "@type": String(
                                        "g:Map",
                                    ),
                                    "@value": Array([
                                        String(
                                            "propname",
                                        ),
                                        Object({
                                            "@type": String(
                                                "g:List",
                                            ),
                                            "@value": Array([
                                                Bool(
                                                    false,
                                                ),
                                            ]),
                                        }),
                                    ]),
                                }),
```

as opposed to:

```
Object({
                                    "@type": String(
                                        "g:Map",
                                    ),
                                    "@value": Array([
                                        String(
                                            "propname",
                                        ),
                                        Object({
                                            "@type": String(
                                                "g:List",
                                            ),
                                            "@value": Array([
                                                Object({
                                                    "@type": String(
                                                        "g:Int32",
                                                    ),
                                                    "@value": Number(
                                                        0,
                                                    ),
                                                }),
                                            ]),
                                        }),
                                    ]),
                                }),
```

Which makes me wonder if there isn't something strange going on within the Tinkerpop gremlin server side of things, producing somewhat unexpected output.  It's possible this is a workaround to a problem in Tinkerpop rather than a real bug fix here.  However, I think it should be harmless in cases where a server behaves more consistently and packages the boolean property into an object with a type and value.