### PR TITLE
Adds repeat, until & emit functionality on GraphTraversal & AnonGraphTraversal + expose fn to get generated bytecode

### DIFF
--- a/gremlin-client/src/client.rs
+++ b/gremlin-client/src/client.rs
@@ -130,7 +130,10 @@ impl GremlinClient {
         Ok(GResultSet::new(self.clone(), results, response, conn))
     }
 
-    pub fn generate_message(&self, bytecode: &Bytecode) -> GremlinResult<Message<serde_json::Value>> {
+    pub fn generate_message(
+        &self,
+        bytecode: &Bytecode,
+    ) -> GremlinResult<Message<serde_json::Value>> {
         let mut args = HashMap::new();
 
         args.insert(String::from("gremlin"), GValue::Bytecode(bytecode.clone()));
@@ -150,7 +153,11 @@ impl GremlinClient {
 
         let args = self.options.serializer.write(&GValue::from(args))?;
 
-        Ok(message_with_args(String::from("bytecode"), String::from("traversal"), args))
+        Ok(message_with_args(
+            String::from("bytecode"),
+            String::from("traversal"),
+            args,
+        ))
     }
 
     pub(crate) fn submit_traversal(&self, bytecode: &Bytecode) -> GremlinResult<GResultSet> {

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -126,6 +126,7 @@ pub use connection::{ConnectionOptions, TlsOptions};
 pub use conversion::{BorrowFromGValue, FromGValue, ToGValue};
 pub use error::GremlinError;
 pub use io::GraphSON;
+pub use message::Message;
 
 pub type GremlinResult<T> = Result<T, error::GremlinError>;
 

--- a/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
+++ b/gremlin-client/src/process/traversal/anonymous_traversal_source.rs
@@ -2,7 +2,9 @@ use crate::process::traversal::step::has::HasStep;
 use crate::process::traversal::step::loops::LoopsStep;
 use crate::process::traversal::step::not::NotStep;
 use crate::process::traversal::step::or::OrStep;
+use crate::process::traversal::step::repeat::RepeatStep;
 use crate::process::traversal::step::select::SelectStep;
+use crate::process::traversal::step::until::UntilStep;
 use crate::process::traversal::step::where_step::WhereStep;
 use crate::process::traversal::TraversalBuilder;
 use crate::structure::{Either2, GIDs, IntoPredicate, Labels, T};
@@ -216,6 +218,24 @@ impl AnonymousTraversalSource {
         A: Into<GValue>,
     {
         self.traversal.clone().constant(value)
+    }
+
+    pub fn until<A>(&self, step: A) -> TraversalBuilder
+    where
+        A: Into<UntilStep>,
+    {
+        self.traversal.clone().until(step)
+    }
+
+    pub fn repeat<A>(&self, step: A) -> TraversalBuilder
+    where
+        A: Into<RepeatStep>,
+    {
+        self.traversal.clone().repeat(step)
+    }
+
+    pub fn emit(&self) -> TraversalBuilder {
+        self.traversal.clone().emit()
     }
 }
 

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -644,4 +644,9 @@ impl TraversalBuilder {
             .add_step(String::from("constant"), vec![value.into()]);
         self
     }
+
+    pub fn emit(mut self) -> Self {
+        self.bytecode.add_step(String::from("emit"), vec![]);
+        self
+    }
 }

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -683,4 +683,9 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         self.builder = self.builder.constant(value);
         self
     }
+
+    pub fn emit(mut self) -> Self {
+        self.builder = self.builder.emit();
+        self
+    }
 }


### PR DESCRIPTION
Found it useful to have a function exposed where I could leverage the bytecode generation built into gremlin-rs; hence I added `generate_message()`. Allowed me to write some queries in gremlin-rs and then have the bytecode available to send to some other endpoint for further analysis or persistence.