### PR TITLE
Session support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 target
 /.directory
+.vscode/

--- a/docker-compose/version-3/gremlin-server-v3.yaml
+++ b/docker-compose/version-3/gremlin-server-v3.yaml
@@ -34,8 +34,8 @@ serializers:
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 2000
-keepAliveInterval: 1000
+idleConnectionTimeout: 0
+keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-client/src/aio/client.rs
+++ b/gremlin-client/src/aio/client.rs
@@ -16,8 +16,15 @@ use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 
 #[derive(Clone)]
+pub struct Session {
+    pool: Pool<GremlinConnectionManager>,
+    name: String,
+}
+
+#[derive(Clone)]
 pub struct GremlinClient {
     pool: Pool<GremlinConnectionManager>,
+    session: Option<Session>,
     alias: Option<String>,
     pub(crate) options: ConnectionOptions,
 }
@@ -35,9 +42,21 @@ impl GremlinClient {
 
         Ok(GremlinClient {
             pool,
+            session: None,
             alias: None,
             options: opts,
         })
+    }
+
+    pub async fn create_session(&mut self, name: String) -> GremlinResult<()> {
+        let manager = GremlinConnectionManager::new(self.options.clone());
+        let pool = Pool::builder().max_open(1).build(manager);
+        self.session = Some(Session { pool, name });
+        Ok(())
+    }
+
+    pub fn close_session(&mut self) {
+        self.session = None
     }
 
     /// Return a cloned client with the provided alias
@@ -85,15 +104,30 @@ impl GremlinClient {
 
         args.insert(String::from("bindings"), GValue::from(bindings));
 
+        if let Some(session) = &self.session {
+            args.insert(String::from("session"), GValue::from(session.name.clone()));
+        }
+
         let args = self.options.serializer.write(&GValue::from(args))?;
 
-        let message = match self.options.serializer {
-            GraphSON::V1 => message_with_args_v1(String::from("eval"), String::default(), args),
-            GraphSON::V2 => message_with_args_v2(String::from("eval"), String::default(), args),
-            GraphSON::V3 => message_with_args(String::from("eval"), String::default(), args),
+        let processor = if self.session.is_some() {
+            "session".to_string()
+        } else {
+            String::default()
         };
 
-        let conn = self.pool.get().await?;
+        let message = match self.options.serializer {
+            GraphSON::V1 => message_with_args_v1(String::from("eval"), processor, args),
+            GraphSON::V2 => message_with_args_v2(String::from("eval"), processor, args),
+            GraphSON::V3 => message_with_args(String::from("eval"), processor, args),
+        };
+
+        let conn = if let Some(session) = &self.session {
+            session.pool.get().await?
+        } else {
+            self.pool.get().await?
+        };
+
         self.send_message_new(conn, message).await
     }
 

--- a/gremlin-client/tests/integration_client.rs
+++ b/gremlin-client/tests/integration_client.rs
@@ -28,17 +28,16 @@ fn test_empty_query() {
 #[test]
 fn test_session_empty_query() {
     let mut graph = graph();
-    graph
+    let sessioned_graph = graph
         .create_session("test-session".to_string())
         .expect("It should create a session.");
     assert_eq!(
         0,
-        graph
+        sessioned_graph
             .execute("g.V().hasLabel('Not Found')", &[])
             .expect("It should execute a traversal")
             .count()
     );
-    graph.close_session();
 }
 
 #[test]

--- a/gremlin-client/tests/integration_client.rs
+++ b/gremlin-client/tests/integration_client.rs
@@ -26,6 +26,22 @@ fn test_empty_query() {
 }
 
 #[test]
+fn test_session_empty_query() {
+    let mut graph = graph();
+    graph
+        .create_session("test-session".to_string())
+        .expect("It should create a session.");
+    assert_eq!(
+        0,
+        graph
+            .execute("g.V().hasLabel('Not Found')", &[])
+            .expect("It should execute a traversal")
+            .count()
+    );
+    graph.close_session();
+}
+
+#[test]
 fn test_ok_credentials() {
     let client = GremlinClient::connect(
         ConnectionOptions::builder()

--- a/gremlin-client/tests/integration_client_async.rs
+++ b/gremlin-client/tests/integration_client_async.rs
@@ -61,23 +61,22 @@ mod aio {
     #[cfg_attr(feature = "async-std-runtime", async_std::test)]
     async fn test_session_empty_query() {
         let mut graph = connect().await;
-        graph
+        let sessioned_graph = graph
             .create_session("test-session".to_string())
             .await
             .expect("It should create a session");
 
         assert_eq!(
             0,
-            graph
+            sessioned_graph
                 .execute("g.V().hasLabel('NotFound')", &[])
                 .await
                 .expect("It should execute a traversal")
                 .count()
                 .await
         );
-
-        graph.close_session();
     }
+
     #[cfg(feature = "async-std-runtime")]
     #[cfg_attr(feature = "async-std-runtime", async_std::test)]
     async fn test_keep_alive_query() {

--- a/gremlin-client/tests/integration_client_async.rs
+++ b/gremlin-client/tests/integration_client_async.rs
@@ -63,6 +63,7 @@ mod aio {
         let mut graph = connect().await;
         graph
             .create_session("test-session".to_string())
+            .await
             .expect("It should create a session");
 
         assert_eq!(

--- a/gremlin-client/tests/integration_client_async.rs
+++ b/gremlin-client/tests/integration_client_async.rs
@@ -59,6 +59,26 @@ mod aio {
 
     #[cfg(feature = "async-std-runtime")]
     #[cfg_attr(feature = "async-std-runtime", async_std::test)]
+    async fn test_session_empty_query() {
+        let mut graph = connect().await;
+        graph
+            .create_session("test-session".to_string())
+            .expect("It should create a session");
+
+        assert_eq!(
+            0,
+            graph
+                .execute("g.V().hasLabel('NotFound')", &[])
+                .await
+                .expect("It should execute a traversal")
+                .count()
+                .await
+        );
+
+        graph.close_session();
+    }
+    #[cfg(feature = "async-std-runtime")]
+    #[cfg_attr(feature = "async-std-runtime", async_std::test)]
     async fn test_keep_alive_query() {
         let graph = connect().await;
 


### PR DESCRIPTION
This PR provides an initial implementation of session support. If merged, it should close #113.

- The change adds two functions, `openSession` and `closeSession` to the `GremlinClient`, both synchronous and asynchronous.
- Internally, the `openSession` function creates a new pool with just a single connection for the session, along with tracking the session name, which the client of the library will most often set to the `String` representation of a UUID. An alternative would've been to just create a single `Connection` rather than a pool of 1, but using the pool allowed for greater re-use of existing functions without changes, because many of the functions involved in sending messages take a managed connection from the pool.
- Queries that are sent using `execute` are sent to the session processor wi the session name, until the session is closed.

Notably, I did learn a few things that might be viewed as limitations on the implementation.

- Sessions are supported only for text queries, not binary traversals. This seems to be a design choice on the server end, so I don't think there's anything that can be done about it in the client.
- The server sends WebSocket ping requests to the client as keep-alive test. The Gremlin client currently doesn't recognize or know how to handle those pings (by sending a pong response). Implementing robust handling for those would likely require either a monitoring thread to read and respond to them, or an asynchronous equivalent. For now, I resolved the problem by setting `idleConnectionTimeout` and `keepAliveInterval` to disable the ping/pong keep-alive messages altogether, to avoid that complexity. That should work fine for my use case but could be a limitation for others.

As always, I welcome any review comments or requests for changes that I need to make in order for the PR to be suitable to merge.