### PR TITLE
Fixed precision of g:Date values to milliseconds

### DIFF
--- a/gremlin-client/src/io/mod.rs
+++ b/gremlin-client/src/io/mod.rs
@@ -59,10 +59,10 @@ impl GraphSON {
                 "@type" : "g:UUID",
                 "@value" : s.to_string()
             })),
-            (GraphSON::V1, GValue::Date(d)) => Ok(json!(d.timestamp())),
+            (GraphSON::V1, GValue::Date(d)) => Ok(json!(d.timestamp_millis())),
             (_, GValue::Date(d)) => Ok(json!({
                 "@type" : "g:Date",
-                "@value" : d.timestamp()
+                "@value" : d.timestamp_millis()
             })),
             (GraphSON::V1, GValue::List(d)) => {
                 let elements: GremlinResult<Vec<Value>> = d.iter().map(|e| self.write(e)).collect();

--- a/gremlin-client/src/io/serializer_v2.rs
+++ b/gremlin-client/src/io/serializer_v2.rs
@@ -503,7 +503,10 @@ mod tests {
         });
 
         let result = deserializer_v2(&value).expect("Failed to deserialize Date");
-        assert_eq!(result, GValue::Date(chrono::Utc.timestamp_millis(1551825863)));
+        assert_eq!(
+            result,
+            GValue::Date(chrono::Utc.timestamp_millis(1551825863))
+        );
 
         // UUID
         let value = json!({

--- a/gremlin-client/src/io/serializer_v2.rs
+++ b/gremlin-client/src/io/serializer_v2.rs
@@ -41,7 +41,7 @@ where
     T: Fn(&Value) -> GremlinResult<GValue>,
 {
     let val = expect_i64!(val);
-    Ok(GValue::from(Utc.timestamp(val, 0)))
+    Ok(GValue::from(Utc.timestamp_millis(val)))
 }
 
 // Long deserializer [docs](http://tinkerpop.apache.org/docs/current/dev/io/#_long_2)
@@ -502,8 +502,8 @@ mod tests {
             "@value": 1551825863
         });
 
-        let result = deserializer_v2(&value).expect("Failed to deserialize Double");
-        assert_eq!(result, GValue::Date(chrono::Utc.timestamp(1551825863, 0)));
+        let result = deserializer_v2(&value).expect("Failed to deserialize Date");
+        assert_eq!(result, GValue::Date(chrono::Utc.timestamp_millis(1551825863)));
 
         // UUID
         let value = json!({

--- a/gremlin-client/src/io/serializer_v3.rs
+++ b/gremlin-client/src/io/serializer_v3.rs
@@ -42,7 +42,7 @@ where
     T: Fn(&Value) -> GremlinResult<GValue>,
 {
     let val = expect_i64!(val);
-    Ok(GValue::from(Utc.timestamp(val, 0)))
+    Ok(GValue::from(Utc.timestamp_millis(val)))
 }
 
 // Long deserializer [docs](http://tinkerpop.apache.org/docs/current/dev/io/#_long_2)
@@ -532,8 +532,8 @@ mod tests {
             "@value": 1551825863
         });
 
-        let result = deserializer_v3(&value).expect("Failed to deserialize Double");
-        assert_eq!(result, GValue::Date(chrono::Utc.timestamp(1551825863, 0)));
+        let result = deserializer_v3(&value).expect("Failed to deserialize Date");
+        assert_eq!(result, GValue::Date(chrono::Utc.timestamp_millis(1551825863)));
 
         // UUID
         let value = json!({

--- a/gremlin-client/src/io/serializer_v3.rs
+++ b/gremlin-client/src/io/serializer_v3.rs
@@ -533,7 +533,10 @@ mod tests {
         });
 
         let result = deserializer_v3(&value).expect("Failed to deserialize Date");
-        assert_eq!(result, GValue::Date(chrono::Utc.timestamp_millis(1551825863)));
+        assert_eq!(
+            result,
+            GValue::Date(chrono::Utc.timestamp_millis(1551825863))
+        );
 
         // UUID
         let value = json!({

--- a/gremlin-client/tests/integration_client.rs
+++ b/gremlin-client/tests/integration_client.rs
@@ -220,7 +220,7 @@ fn test_complex_vertex_creation_with_properties() {
     );
 
     assert_eq!(
-        &chrono::Utc.timestamp(1551825863, 0),
+        &chrono::Utc.timestamp_millis(1551825863),
         properties["date"].get::<List>().unwrap()[0]
             .get::<VertexProperty>()
             .unwrap()
@@ -267,6 +267,41 @@ fn test_complex_vertex_creation_with_properties() {
             .get::<VertexProperty>()
             .unwrap()
             .get::<chrono::DateTime<chrono::Utc>>()
+            .unwrap()
+    );
+}
+
+#[test]
+fn test_inserting_date_with_milisecond_precision() {
+    use chrono::offset::TimeZone;
+    use chrono::DateTime;
+    use chrono::Utc;
+
+    let graph = graph();
+
+    let q = r#"g.addV('person').property('dateTime',dateTime).propertyMap()"#;
+
+    let expected = chrono::Utc.timestamp(1551825863, 0);
+    let params: &[(&str, &dyn ToGValue)] = &[("dateTime", &expected)];
+
+    let results = graph
+        .execute(q, params)
+        .expect("it should execute addV")
+        .filter_map(Result::ok)
+        .map(|f| f.take::<Map>())
+        .collect::<Result<Vec<Map>, _>>()
+        .expect("It should be ok");
+
+    let properties = &results[0];
+
+    assert_eq!(1, properties.len());
+
+    assert_eq!(
+        &expected,
+        properties["dateTime"].get::<List>().unwrap()[0]
+            .get::<VertexProperty>()
+            .unwrap()
+            .get::<DateTime<Utc>>()
             .unwrap()
     );
 }

--- a/gremlin-client/tests/integration_client_v1.rs
+++ b/gremlin-client/tests/integration_client_v1.rs
@@ -250,7 +250,7 @@ fn test_complex_vertex_creation_with_properties_v1() {
     );
 
     assert_eq!(
-        &1551825863,
+        &1551825863000,
         properties["dateTime"].get::<List>().unwrap()[0]
             .get::<VertexProperty>()
             .unwrap()


### PR DESCRIPTION
Closes #128 

This PR is a breaking change upon dates that are currently serialized since they would be serialized as epoch seconds not epoch milliseconds, but the Tinkerpop standard for [version 2](http://tinkerpop.apache.org/docs/current/dev/io/#_date) and [version 3](http://tinkerpop.apache.org/docs/current/dev/io/#_date_2) expects milliseconds.

Given the library is still major version 0 such breaking changes are permitted per semver expectations, but wanted to call it out for your consideration when reviewing.