### PR TITLE
Close session

### DIFF
--- a/gremlin-client/src/client.rs
+++ b/gremlin-client/src/client.rs
@@ -15,6 +15,30 @@ use std::collections::{HashMap, VecDeque};
 
 type SessionedClient = GremlinClient;
 
+impl SessionedClient {
+    pub fn close_session(&mut self) -> GremlinResult<GResultSet> {
+        if let Some(session_name) = self.session.take() {
+            let mut args = HashMap::new();
+            args.insert(String::from("session"), GValue::from(session_name.clone()));
+            let args = self.options.serializer.write(&GValue::from(args))?;
+
+            let processor = "session".to_string();
+
+            let message = match self.options.serializer {
+                GraphSON::V1 => message_with_args_v1(String::from("close"), processor, args),
+                GraphSON::V2 => message_with_args_v2(String::from("close"), processor, args),
+                GraphSON::V3 => message_with_args(String::from("close"), processor, args),
+            };
+
+            let conn = self.pool.get()?;
+
+            self.send_message(conn, message)
+        } else {
+            Err(GremlinError::Generic("No session to close".to_string()))
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct GremlinClient {
     pool: Pool<GremlinConnectionManager>,

--- a/gremlin-client/tests/integration_client.rs
+++ b/gremlin-client/tests/integration_client.rs
@@ -41,6 +41,7 @@ fn test_session_empty_query() {
             .expect("It should execute a traversal")
             .count()
     );
+    sessioned_graph.close_session().expect("It should close the session.");
 }
 
 #[test]

--- a/gremlin-client/tests/integration_client.rs
+++ b/gremlin-client/tests/integration_client.rs
@@ -41,7 +41,9 @@ fn test_session_empty_query() {
             .expect("It should execute a traversal")
             .count()
     );
-    sessioned_graph.close_session().expect("It should close the session.");
+    sessioned_graph
+        .close_session()
+        .expect("It should close the session.");
 }
 
 #[test]

--- a/gremlin-client/tests/integration_client.rs
+++ b/gremlin-client/tests/integration_client.rs
@@ -31,7 +31,7 @@ fn test_empty_query() {
 #[test]
 fn test_session_empty_query() {
     let mut graph = graph();
-    let sessioned_graph = graph
+    let mut sessioned_graph = graph
         .create_session("test-session".to_string())
         .expect("It should create a session.");
     assert_eq!(

--- a/gremlin-client/tests/integration_client_async.rs
+++ b/gremlin-client/tests/integration_client_async.rs
@@ -61,7 +61,7 @@ mod aio {
     #[cfg_attr(feature = "async-std-runtime", async_std::test)]
     async fn test_session_empty_query() {
         let mut graph = connect().await;
-        let sessioned_graph = graph
+        let mut sessioned_graph = graph
             .create_session("test-session".to_string())
             .await
             .expect("It should create a session");

--- a/gremlin-client/tests/integration_client_async.rs
+++ b/gremlin-client/tests/integration_client_async.rs
@@ -75,8 +75,11 @@ mod aio {
                 .count()
                 .await
         );
-        
-        sessioned_graph.close_session().await.expect("It should close the session.");
+
+        sessioned_graph
+            .close_session()
+            .await
+            .expect("It should close the session.");
     }
 
     #[cfg(feature = "async-std-runtime")]

--- a/gremlin-client/tests/integration_client_async.rs
+++ b/gremlin-client/tests/integration_client_async.rs
@@ -75,6 +75,8 @@ mod aio {
                 .count()
                 .await
         );
+        
+        sessioned_graph.close_session().await.expect("It should close the session.");
     }
 
     #[cfg(feature = "async-std-runtime")]


### PR DESCRIPTION
@wolf4ood, it looks like I missed something when I submitted the contribution for sessions a while back. There's some additional code necessary to allow the client to gracefully close sessions. Absent that, it leaves them hanging, which has different (and sometimes poor) behavior across different Gremlin-speaking servers.  This PR adds a `close_session` function that properly closes down a `SessionedClient`.