### PR TITLE
Expose AsyncTerminator as gremlin::client::aio:AsyncTerminator

### DIFF
--- a/gremlin-client/src/aio/mod.rs
+++ b/gremlin-client/src/aio/mod.rs
@@ -6,5 +6,5 @@ mod result;
 mod error;
 pub(crate) mod process;
 pub use client::GremlinClient;
-pub use result::GResultSet;
 pub use process::traversal::AsyncTerminator;
+pub use result::GResultSet;

--- a/gremlin-client/src/aio/mod.rs
+++ b/gremlin-client/src/aio/mod.rs
@@ -7,3 +7,4 @@ mod error;
 pub(crate) mod process;
 pub use client::GremlinClient;
 pub use result::GResultSet;
+pub use process::traversal::AsyncTerminator;


### PR DESCRIPTION
As mentioned in https://github.com/wolf4ood/gremlin-rs/pull/123 it seems there needs to be a little more to fully expose `AsyncTerminator`. @wolf4ood for your review at your convenience.