### PR TITLE
Collection Type Conversions

### DIFF
--- a/gremlin-client/src/error.rs
+++ b/gremlin-client/src/error.rs
@@ -22,7 +22,7 @@ pub enum GremlinError {
     Pool(#[from] r2d2::Error),
 
     #[error("Got wrong type {0:?}")]
-    WrontType(GValue),
+    WrongType(GValue),
 
     #[error("Cast error: {0}")]
     Cast(String),

--- a/gremlin-client/src/structure/list.rs
+++ b/gremlin-client/src/structure/list.rs
@@ -39,6 +39,12 @@ impl Into<List> for Vec<GValue> {
     }
 }
 
+impl From<List> for Vec<GValue> {
+    fn from(list: List) -> Self {
+        list.take()
+    }
+}
+
 impl std::ops::Index<usize> for List {
     type Output = GValue;
 

--- a/gremlin-client/src/structure/map.rs
+++ b/gremlin-client/src/structure/map.rs
@@ -4,6 +4,7 @@ use crate::GremlinResult;
 use crate::Token;
 use std::collections::hash_map::IntoIter;
 use std::collections::{BTreeMap, HashMap};
+use std::convert::{TryFrom, TryInto};
 
 /// Represent a Map<[GKey](struct.GKey),[GValue](struct.GValue)> which has ability to allow for non-String keys.
 /// TinkerPop type [here](http://tinkerpop.apache.org/docs/current/dev/io/#_map)
@@ -22,6 +23,12 @@ impl From<HashMap<GKey, GValue>> for Map {
     }
 }
 
+impl From<Map> for HashMap<GKey, GValue> {
+    fn from(map: Map) -> Self {
+        map.0
+    }
+}
+
 impl From<HashMap<String, GValue>> for Map {
     fn from(val: HashMap<String, GValue>) -> Self {
         let map = val.into_iter().map(|(k, v)| (GKey::String(k), v)).collect();
@@ -29,10 +36,30 @@ impl From<HashMap<String, GValue>> for Map {
     }
 }
 
+impl TryFrom<Map> for HashMap<String, GValue> {
+    type Error = GremlinError;
+
+    fn try_from(map: Map) -> Result<Self, Self::Error> {
+        map.into_iter()
+            .map(|(k, v)| Ok((k.try_into()?, v)))
+            .collect()
+    }
+}
+
 impl From<BTreeMap<String, GValue>> for Map {
     fn from(val: BTreeMap<String, GValue>) -> Self {
         let map = val.into_iter().map(|(k, v)| (GKey::String(k), v)).collect();
         Map(map)
+    }
+}
+
+impl TryFrom<Map> for BTreeMap<String, GValue> {
+    type Error = GremlinError;
+
+    fn try_from(map: Map) -> Result<Self, Self::Error> {
+        map.into_iter()
+            .map(|(k, v)| Ok((k.try_into()?, v)))
+            .collect()
     }
 }
 
@@ -125,6 +152,20 @@ impl From<&str> for GKey {
 impl From<String> for GKey {
     fn from(val: String) -> Self {
         GKey::String(val)
+    }
+}
+
+impl TryFrom<GKey> for String {
+    type Error = GremlinError;
+
+    fn try_from(k: GKey) -> Result<Self, Self::Error> {
+        if let GKey::String(s) = k {
+            Ok(s)
+        } else {
+            Err(GremlinError::Cast(String::from(
+                "Cannot cast from this GKey to String",
+            )))
+        }
     }
 }
 

--- a/gremlin-client/src/structure/map.rs
+++ b/gremlin-client/src/structure/map.rs
@@ -162,9 +162,10 @@ impl TryFrom<GKey> for String {
         if let GKey::String(s) = k {
             Ok(s)
         } else {
-            Err(GremlinError::Cast(String::from(
-                "Cannot cast from this GKey to String",
-            )))
+            Err(GremlinError::Cast(String::from(format!(
+                "Cannot cast from {:?} to String",
+                k
+            ))))
         }
     }
 }

--- a/gremlin-client/src/structure/set.rs
+++ b/gremlin-client/src/structure/set.rs
@@ -22,6 +22,12 @@ impl Into<Set> for Vec<GValue> {
     }
 }
 
+impl From<Set> for Vec<GValue> {
+    fn from(set: Set) -> Self {
+        set.take()
+    }
+}
+
 impl IntoIterator for Set {
     type Item = GValue;
     type IntoIter = IntoIter<GValue>;

--- a/gremlin-client/src/structure/value.rs
+++ b/gremlin-client/src/structure/value.rs
@@ -409,6 +409,51 @@ impl std::convert::TryFrom<GValue> for f64 {
     }
 }
 
+impl std::convert::TryFrom<GValue> for BTreeMap<String, GValue> {
+    type Error = crate::GremlinError;
+
+    fn try_from(value: GValue) -> GremlinResult<Self> {
+        if let GValue::Map(m) = value {
+            m.try_into()
+        } else {
+            Err(GremlinError::Cast(format!(
+                "Cannot cast {:?} to HashMap<GKey, GValue>",
+                value
+            )))
+        }
+    }
+}
+
+impl std::convert::TryFrom<GValue> for HashMap<GKey, GValue> {
+    type Error = crate::GremlinError;
+
+    fn try_from(value: GValue) -> GremlinResult<Self> {
+        if let GValue::Map(m) = value {
+            Ok(m.into())
+        } else {
+            Err(GremlinError::Cast(format!(
+                "Cannot cast {:?} to HashMap<GKey, GValue>",
+                value
+            )))
+        }
+    }
+}
+
+impl std::convert::TryFrom<GValue> for HashMap<String, GValue> {
+    type Error = crate::GremlinError;
+
+    fn try_from(value: GValue) -> GremlinResult<Self> {
+        if let GValue::Map(m) = value {
+            m.try_into()
+        } else {
+            Err(GremlinError::Cast(format!(
+                "Cannot cast {:?} to HashMap<GKey, GValue>",
+                value
+            )))
+        }
+    }
+}
+
 fn from_list<T>(glist: List) -> GremlinResult<T>
 where
     T: std::convert::TryFrom<GValue, Error = GremlinError>,


### PR DESCRIPTION
As I'm working with gremlin-rs, I've noticed that I had to write a handful of helper functions to shuffle collections from `GValue` types back and forth with standard library collection types based on `Vec` and `HashMap`.  This pull request proposes to add a few more `From` and `TryFrom` implementations to `gremlin-rs` types as a convenience feature.