### PR TITLE
Add elementMap step

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ in order to specify the version of the Gremlin Server
 
 ```
 cd docker-compose
-export GREMLIN_SERVER=3.4.0
+export GREMLIN_SERVER=3.4.4
 docker-compose up -d
 cd ..
 cargo test --all-features

--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -329,6 +329,17 @@ impl TraversalBuilder {
         self
     }
 
+    pub fn element_map<L>(mut self, labels: L) -> Self
+    where
+        L: Into<Labels>,
+    {
+        self.bytecode.add_step(
+            String::from("elementMap"),
+            labels.into().0.into_iter().map(GValue::from).collect(),
+        );
+        self
+    }
+
     pub fn count(mut self) -> Self {
         self.bytecode.add_step(String::from("count"), vec![]);
         self

--- a/gremlin-client/src/process/traversal/graph_traversal.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal.rs
@@ -358,6 +358,15 @@ impl<S, E: FromGValue, T: Terminator<E>> GraphTraversal<S, E, T> {
         GraphTraversal::new(self.terminator, self.builder)
     }
 
+    pub fn element_map<L>(mut self, labels: L) -> GraphTraversal<S, Map, T>
+    where
+        L: Into<Labels>,
+        T: Terminator<Map>,
+    {
+        self.builder = self.builder.element_map(labels);
+        GraphTraversal::new(self.terminator, self.builder)
+    }
+
     pub fn count(mut self) -> GraphTraversal<S, i64, T>
     where
         T: Terminator<i64>,

--- a/gremlin-client/src/process/traversal/graph_traversal_source.rs
+++ b/gremlin-client/src/process/traversal/graph_traversal_source.rs
@@ -559,6 +559,43 @@ mod tests {
     }
 
     #[test]
+    fn element_map_step_test() {
+        let g = empty();
+
+        let mut code = Bytecode::new();
+
+        code.add_step(String::from("V"), vec![]);
+        code.add_step(String::from("elementMap"), vec![]);
+
+        assert_eq!(&code, g.v(()).element_map(()).bytecode());
+
+        let mut code = Bytecode::new();
+
+        code.add_step(String::from("V"), vec![]);
+        code.add_step(
+            String::from("elementMap"),
+            vec![String::from("name").into()],
+        );
+
+        assert_eq!(&code, g.v(()).element_map("name").bytecode());
+
+        let mut code = Bytecode::new();
+
+        code.add_step(String::from("V"), vec![]);
+        code.add_step(
+            String::from("elementMap"),
+            vec![String::from("name").into(), String::from("surname").into()],
+        );
+
+        assert_eq!(
+            &code,
+            g.v(()).element_map(vec!["name", "surname"]).bytecode()
+        );
+
+        assert_eq!(&code, g.v(()).element_map(["name", "surname"]).bytecode());
+    }
+
+    #[test]
     fn count_test() {
         let g = empty();
 

--- a/gremlin-client/tests/integration_traversal.rs
+++ b/gremlin-client/tests/integration_traversal.rs
@@ -714,7 +714,7 @@ fn test_value_map() {
 }
 
 #[test]
-fn test_uwnrap_map() {
+fn test_unwrap_map() {
     let client = graph();
 
     let g = traversal().with_remote(client);
@@ -741,6 +741,49 @@ fn test_uwnrap_map() {
     assert_eq!(id.unwrap(), v_id);
     assert_eq!(property.unwrap(), "test");
     assert_eq!(label.unwrap(), "test_value_map");
+}
+
+#[test]
+fn test_element_map() {
+    let client = graph();
+
+    let g = traversal().with_remote(client);
+
+    let vertices = g
+        .add_v("test_element_map")
+        .property("name", "test")
+        .to_list()
+        .unwrap();
+
+    let vertex = &vertices[0];
+
+    let results = g.v(vertex.id()).element_map(()).to_list().unwrap();
+
+    assert_eq!(1, results.len());
+
+    let value = &results[0];
+
+    assert_eq!("test", value["name"].get::<String>().unwrap());
+
+    let results = g.v(vertex.id()).element_map("name").to_list().unwrap();
+
+    assert_eq!(1, results.len());
+
+    let value = &results[0];
+
+    assert_eq!("test", value["name"].get::<String>().unwrap());
+
+    let results = g.v(vertex.id()).element_map("fake").to_list().unwrap();
+
+    assert_eq!(2, results[0].len());
+    assert_eq!(true, results[0].get("id").is_some());
+    assert_eq!(true, results[0].get("label").is_some());
+
+    let results = g.v(vertex.id()).element_map(()).to_list().unwrap();
+
+    assert_eq!(true, results[0].get("id").is_some());
+    assert_eq!(true, results[0].get("label").is_some());
+    assert_eq!(true, results[0].get("name").is_some());
 }
 
 #[test]

--- a/gremlin-client/tests/integration_traversal_v2.rs
+++ b/gremlin-client/tests/integration_traversal_v2.rs
@@ -717,7 +717,7 @@ fn test_value_map_v2() {
 }
 
 #[test]
-fn test_uwnrap_map_v2() {
+fn test_unwrap_map_v2() {
     let client = graph_serializer(GraphSON::V2);
 
     let g = traversal().with_remote(client);
@@ -744,6 +744,49 @@ fn test_uwnrap_map_v2() {
     assert_eq!(id.unwrap(), v_id);
     assert_eq!(property.unwrap(), "test");
     assert_eq!(label.unwrap(), "test_value_map");
+}
+
+#[test]
+fn test_element_map_v2() {
+    let client = graph_serializer(GraphSON::V2);
+
+    let g = traversal().with_remote(client);
+
+    let vertices = g
+        .add_v("test_element_map")
+        .property("name", "test")
+        .to_list()
+        .unwrap();
+
+    let vertex = &vertices[0];
+
+    let results = g.v(vertex.id()).element_map(()).to_list().unwrap();
+
+    assert_eq!(1, results.len());
+
+    let value = &results[0];
+
+    assert_eq!("test", value["name"].get::<String>().unwrap());
+
+    let results = g.v(vertex.id()).element_map("name").to_list().unwrap();
+
+    assert_eq!(1, results.len());
+
+    let value = &results[0];
+
+    assert_eq!("test", value["name"].get::<String>().unwrap());
+
+    let results = g.v(vertex.id()).element_map("fake").to_list().unwrap();
+
+    assert_eq!(2, results[0].len());
+    assert_eq!(true, results[0].get("id").is_some());
+    assert_eq!(true, results[0].get("label").is_some());
+
+    let results = g.v(vertex.id()).element_map(()).to_list().unwrap();
+
+    assert_eq!(true, results[0].get("id").is_some());
+    assert_eq!(true, results[0].get("label").is_some());
+    assert_eq!(true, results[0].get("name").is_some());
 }
 
 #[test]


### PR DESCRIPTION
Adds support for the elementMap step from TinkerPop 3.4.4+

https://tinkerpop.apache.org/docs/current/reference/#elementmap-step