### PR TITLE
Remove Websocket & Time crates

### DIFF
--- a/gremlin-client/Cargo.toml
+++ b/gremlin-client/Cargo.toml
@@ -43,6 +43,7 @@ chrono = { version = "0.4", default-features = false}
 lazy_static = "1.3.0"
 base64 = "0.13.1"
 native-tls = "0.2.3"
+tungstenite = { version = "0.18.0", features = ["native-tls"] }
 async-tungstenite = { version = "0.18", optional = true, default-features=false}
 async-std =  { version = "1.4.0", optional = true, features = ["unstable","attributes"] }
 async-trait = { version = "0.1.10", optional = true }
@@ -62,11 +63,6 @@ futures = { version = "0.3.1", optional = true}
 pin-project-lite = { version = "0.2", optional = true}
 tokio = { version = "1", optional=true, features = ["full"] }
 
-
-[dependencies.websocket]
-version="0.26"
-default-features = false 
-features = ["sync","sync-ssl"]
 
 [dependencies.uuid]
 features = ["serde", "v4"]

--- a/gremlin-client/Cargo.toml
+++ b/gremlin-client/Cargo.toml
@@ -38,7 +38,8 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive="1.0"
 r2d2 = "0.8.3"
-chrono = "0.4"
+#Avoids bringing in time crate (https://github.com/time-rs/time/issues/293)
+chrono = { version = "0.4", default-features = false}
 lazy_static = "1.3.0"
 base64 = "0.13.1"
 native-tls = "0.2.3"

--- a/gremlin-client/src/connection.rs
+++ b/gremlin-client/src/connection.rs
@@ -28,7 +28,6 @@ impl ConnectionStream {
             _ => None,
         };
 
-        // TcpStream::connect(addr)
         let request = options
             .websocket_url()
             .into_client_request()

--- a/gremlin-client/src/error.rs
+++ b/gremlin-client/src/error.rs
@@ -2,10 +2,6 @@ use crate::structure::GValue;
 
 use thiserror::Error;
 
-use websocket::WebSocketError;
-
-#[cfg(feature = "async_gremlin")]
-use async_tungstenite::tungstenite;
 #[cfg(feature = "async_gremlin")]
 use mobc;
 
@@ -16,7 +12,7 @@ pub enum GremlinError {
     Generic(String),
 
     #[error(transparent)]
-    WebSocket(#[from] WebSocketError),
+    WebSocket(#[from] tungstenite::error::Error),
 
     #[error(transparent)]
     Pool(#[from] r2d2::Error),
@@ -38,7 +34,7 @@ pub enum GremlinError {
 
     #[cfg(feature = "async_gremlin")]
     #[error(transparent)]
-    WebSocketAsync(#[from] tungstenite::error::Error),
+    WebSocketAsync(#[from] async_tungstenite::tungstenite::Error),
     #[cfg(feature = "async_gremlin")]
     #[error(transparent)]
     ChannelSend(#[from] futures::channel::mpsc::SendError),


### PR DESCRIPTION
I encountered a dependency issue due to the age of dependencies brought in through the websocket-rs crate and this crate's inclusion of `time` through `chrono`.

The websocket-rs crate is bringing a very old version of [hyper](https://github.com/websockets-rs/rust-websocket/blob/74c82be3de282e1c4c35c51daac1a84b583ce8ea/Cargo.toml#L20) and the time crate has a [known issue](https://github.com/time-rs/time/issues/293) but setting the feature flags as done in this PR avoids the issue.

I swapped the websocket-rs crate with using tungstenite which is one of the suggestions listed by websocket-rs and also because this crate already used async-tungstenite.

@wolf4ood if this is acceptable to you mind cutting a new release after its merged?
