### PR TITLE
Add .e traversal step to TraversalBuilder

### DIFF
--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -53,6 +53,17 @@ impl TraversalBuilder {
         self
     }
 
+    pub fn e<T>(mut self, ids: T) -> TraversalBuilder
+    where
+        T: Into<GIDs>,
+    {
+        self.bytecode.add_step(
+            String::from("E"),
+            ids.into().0.iter().map(|id| id.to_gvalue()).collect(),
+        );
+        self
+    }
+
     pub fn has_label<L>(mut self, labels: L) -> Self
     where
         L: Into<Labels>,


### PR DESCRIPTION
I noticed `.e()` is not available on `TraversalBuilder` - this patch adds it.

(I prefer to separate traversal building from the client instance, so that's why I usually use `TraversalBuilder` directly).