### PR TITLE
Support Property/VertexProperty in TryFrom<GValue>

### DIFF
--- a/gremlin-client/src/structure/value.rs
+++ b/gremlin-client/src/structure/value.rs
@@ -333,7 +333,7 @@ impl std::convert::TryFrom<GValue> for i64 {
             GValue::VertexProperty(vp) => vp.take(),
             GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
-                "Cannot cast {:?} to i32",
+                "Cannot cast {:?} to i64",
                 value
             ))),
         }
@@ -433,7 +433,7 @@ impl std::convert::TryFrom<GValue> for BTreeMap<String, GValue> {
             m.try_into()
         } else {
             Err(GremlinError::Cast(format!(
-                "Cannot cast {:?} to HashMap<GKey, GValue>",
+                "Cannot cast {:?} to BTreeMap<String, GValue>",
                 value
             )))
         }
@@ -463,7 +463,7 @@ impl std::convert::TryFrom<GValue> for HashMap<String, GValue> {
             m.try_into()
         } else {
             Err(GremlinError::Cast(format!(
-                "Cannot cast {:?} to HashMap<GKey, GValue>",
+                "Cannot cast {:?} to HashMap<String, GValue>",
                 value
             )))
         }
@@ -478,8 +478,9 @@ where
 
     match vec.len() {
         1 => vec.pop().unwrap().try_into(),
-        _ => Err(GremlinError::Cast(String::from(
-            "Cannot cast a List to String",
+        _ => Err(GremlinError::Cast(format!(
+            "Cannot cast a List to {}",
+            std::any::type_name::<T>(),
         ))),
     }
 }

--- a/gremlin-client/src/structure/value.rs
+++ b/gremlin-client/src/structure/value.rs
@@ -296,6 +296,8 @@ impl std::convert::TryFrom<GValue> for String {
         match value {
             GValue::String(s) => Ok(s),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to String",
                 value
@@ -311,6 +313,8 @@ impl std::convert::TryFrom<GValue> for i32 {
         match value {
             GValue::Int32(s) => Ok(s),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to i32",
                 value
@@ -326,6 +330,8 @@ impl std::convert::TryFrom<GValue> for i64 {
         match value {
             GValue::Int64(s) => Ok(s),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to i32",
                 value
@@ -341,6 +347,8 @@ impl std::convert::TryFrom<GValue> for uuid::Uuid {
         match value {
             GValue::Uuid(uid) => Ok(uid),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to Uuid",
                 value
@@ -356,6 +364,8 @@ impl std::convert::TryFrom<GValue> for Date {
         match value {
             GValue::Date(date) => Ok(date),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to DateTime<Utc>",
                 value
@@ -371,6 +381,8 @@ impl std::convert::TryFrom<GValue> for bool {
         match value {
             GValue::Bool(val) => Ok(val),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to bool",
                 value
@@ -386,6 +398,8 @@ impl std::convert::TryFrom<GValue> for f32 {
         match value {
             GValue::Float(x) => Ok(x),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to f32",
                 value
@@ -401,6 +415,8 @@ impl std::convert::TryFrom<GValue> for f64 {
         match value {
             GValue::Double(x) => Ok(x),
             GValue::List(s) => from_list(s),
+            GValue::VertexProperty(vp) => vp.take(),
+            GValue::Property(p) => p.take(),
             _ => Err(GremlinError::Cast(format!(
                 "Cannot cast {:?} to f64",
                 value


### PR DESCRIPTION
This facilitates things like executing gremlin `propertyMap` and then handling the results with `FromGMap`.