### PR TITLE
Feature/trim native tls and features

### DIFF
--- a/gremlin-client/Cargo.toml
+++ b/gremlin-client/Cargo.toml
@@ -11,20 +11,13 @@ categories = ["database"]
 readme = "README.md"
 
 
-
 [features]
 
-default = []
-
-
-
-async_gremlin = ["futures","mobc","async-tungstenite","async-trait","url","pin-project-lite"]
-
-async_std = ["async-std-runtime"]
-tokio-runtime = ["async_gremlin","tokio","mobc/tokio","async-tungstenite/tokio-runtime","async-tungstenite/tokio-native-tls","tokio-native-tls","tokio-stream"]
-async-std-runtime = ["async_gremlin","async-std","async-tungstenite/async-std-runtime","async-tungstenite/async-tls","mobc/async-std","async-tls","rustls","webpki"]
-
-derive = ["gremlin-derive"] 
+default = ["async-std-runtime"]
+async_gremlin = ["futures", "mobc", "async-tungstenite", "async-trait", "url", "pin-project-lite"]
+tokio-runtime = ["async_gremlin", "tokio", "mobc/tokio", "async-tungstenite/tokio-runtime", "tokio-rustls", "tokio-stream", "tokio"]
+async-std-runtime = ["async_gremlin", "async-std", "async-tungstenite/async-std-runtime", "async-tungstenite/async-tls", "async-tls", "mobc/async-std", "rustls", "webpki"]
+derive = ["gremlin-derive"]
 
 [badges]
 travis-ci = { repository = "wolf4ood/gremlin-rs" }
@@ -33,42 +26,35 @@ is-it-maintained-issue-resolution = { repository = "wolf4ood/gremlin-rs" }
 is-it-maintained-open-issues = { repository = "wolf4ood/gremlin-rs" }
 maintenance = {status = "actively-developed"}
 
+
 [dependencies]
+async-std = { version = "1.4.0", features = ["unstable","attributes"], optional = true }
+async-tls = { git = "https://github.com/mlemesle/async-tls", branch = "chore/bump-rustls", optional = true }
+async-trait = { version = "0.1.10", optional = true }
+async-tungstenite = { git = "https://github.com/mlemesle/async-tungstenite", branch = "chore/bump-async-tls", default-features = false, optional = true }
+base64 = "0.13.1"
+#Avoids bringing in time crate (https://github.com/time-rs/time/issues/293)
+chrono = { version = "0.4", default-features = false }
+futures = { version = "0.3.1", optional = true }
+gremlin-derive = { path = "../gremlin-derive", version = "0.1", optional = true }
+lazy_static = "1.3.0"
+mobc = { version = "0.7", default-features = false, features = ["unstable"], optional = true }
+pin-project-lite = { version = "0.2", optional = true }
+r2d2 = "0.8.3"
+rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
 serde = "1.0"
 serde_json = "1.0"
-serde_derive="1.0"
-r2d2 = "0.8.3"
-#Avoids bringing in time crate (https://github.com/time-rs/time/issues/293)
-chrono = { version = "0.4", default-features = false}
-lazy_static = "1.3.0"
-base64 = "0.13.1"
-native-tls = "0.2.3"
-tungstenite = { version = "0.18.0", features = ["native-tls"] }
-async-tungstenite = { version = "0.18", optional = true, default-features=false}
-async-std =  { version = "1.4.0", optional = true, features = ["unstable","attributes"] }
-async-trait = { version = "0.1.10", optional = true }
-async-tls =  { version = "0.11", optional = true }
-tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-stream = { version = "0.1.2", optional = true }
-gremlin-derive = { path="../gremlin-derive", version="0.1", optional=true }
-rustls =   { version="0.19", features = ["dangerous_configuration"], optional = true}
-webpki = { version = "0.21.3", optional = true }
+serde_derive = "1.0"
 thiserror = "1.0.20"
-
-
-
-mobc = {version = "0.7", optional = true, default-features=false, features = ["unstable"] }
-url =  {version = "2.1.0", optional = true}
-futures = { version = "0.3.1", optional = true}
-pin-project-lite = { version = "0.2", optional = true}
-tokio = { version = "1", optional=true, features = ["full"] }
-
-
-[dependencies.uuid]
-features = ["serde", "v4"]
-version = "1.1.2"
-
-
+tokio = { version = "1", features = ["full"], optional = true }
+tokio-native-tls = { version = "0.3.0", optional = true }
+tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration"], optional = true }
+tokio-stream = { version = "0.1.2", optional = true }
+# tungstenite = { version = "0.18", features = ["rustls-tls-webpki-roots"] }
+tungstenite = { git = "https://github.com/snapview/tungstenite-rs", features = ["rustls-tls-webpki-roots"] }
+url = { version = "2.1.0", optional = true }
+uuid = { version = "1.1.2", features = ["serde", "v4"] }
+webpki = { version = "0.21", optional = true }
 
 
 [[example]]

--- a/gremlin-client/Cargo.toml
+++ b/gremlin-client/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 
 [features]
 
-default = ["async-std-runtime"]
+default = []
 async_gremlin = ["futures", "mobc", "async-tungstenite", "async-trait", "url", "pin-project-lite"]
-tokio-runtime = ["async_gremlin", "tokio", "mobc/tokio", "async-tungstenite/tokio-runtime", "tokio-rustls", "tokio-stream", "tokio"]
-async-std-runtime = ["async_gremlin", "async-std", "async-tungstenite/async-std-runtime", "async-tungstenite/async-tls", "async-tls", "mobc/async-std", "rustls", "webpki"]
+tokio-runtime = ["async_gremlin", "tokio", "mobc/tokio", "async-tungstenite/tokio-runtime", "async-tungstenite/tokio-rustls-webpki-roots", "async-tls", "tokio-stream", "tokio-rustls"]
+async-std-runtime = ["async_gremlin", "async-std", "mobc/async-std", "async-tungstenite/async-std-runtime", "async-tungstenite/async-tls", "async-tls", "webpki"]
 derive = ["gremlin-derive"]
 
 [badges]
@@ -31,7 +31,7 @@ maintenance = {status = "actively-developed"}
 async-std = { version = "1.4.0", features = ["unstable","attributes"], optional = true }
 async-tls = { git = "https://github.com/mlemesle/async-tls", branch = "chore/bump-rustls", optional = true }
 async-trait = { version = "0.1.10", optional = true }
-async-tungstenite = { git = "https://github.com/mlemesle/async-tungstenite", branch = "chore/bump-async-tls", default-features = false, optional = true }
+async-tungstenite = { git = "https://github.com/mlemesle/async-tungstenite", rev = "2e1d4d8e1bb117ecd08f23d55d818ac45134b313", default-features = false, optional = true }
 base64 = "0.13.1"
 #Avoids bringing in time crate (https://github.com/time-rs/time/issues/293)
 chrono = { version = "0.4", default-features = false }
@@ -41,14 +41,13 @@ lazy_static = "1.3.0"
 mobc = { version = "0.7", default-features = false, features = ["unstable"], optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 r2d2 = "0.8.3"
-rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 thiserror = "1.0.20"
 tokio = { version = "1", features = ["full"], optional = true }
-tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration"], optional = true }
+tokio-rustls = { version = "0.24", features = ["dangerous_configuration"], optional = true }
 tokio-stream = { version = "0.1.2", optional = true }
 # tungstenite = { version = "0.18", features = ["rustls-tls-webpki-roots"] }
 tungstenite = { git = "https://github.com/snapview/tungstenite-rs", features = ["rustls-tls-webpki-roots"] }

--- a/gremlin-client/src/cert.rs
+++ b/gremlin-client/src/cert.rs
@@ -1,0 +1,28 @@
+// use rustls::client::{ServerCertVerified, ServerCertVerifier};
+
+use rustls::client::{ServerCertVerified, ServerCertVerifier};
+
+pub struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    // fn verify_server_cert(
+    //     &self,
+    //     roots: &rustls::RootCertStore,
+    //     presented_certs: &[rustls::Certificate],
+    //     dns_name: webpki::DNSNameRef,
+    //     ocsp_response: &[u8],
+    // ) -> Result<ServerCertVerified, TLSError> {
+    //     Ok(ServerCertVerified::assertion())
+    // }
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}

--- a/gremlin-client/src/connection.rs
+++ b/gremlin-client/src/connection.rs
@@ -3,7 +3,8 @@ use std::{net::TcpStream, sync::Arc};
 use crate::{cert::NoCertificateVerification, GraphSON, GremlinError, GremlinResult};
 use rustls::ClientConfig;
 use tungstenite::{
-    client::{uri_mode, IntoClientRequest}, client_tls_with_config,
+    client::{uri_mode, IntoClientRequest},
+    client_tls_with_config,
     stream::{MaybeTlsStream, Mode, NoDelay},
     Connector, Message, WebSocket,
 };
@@ -19,10 +20,6 @@ impl std::fmt::Debug for ConnectionStream {
 impl ConnectionStream {
     fn connect(options: ConnectionOptions) -> GremlinResult<Self> {
         let connector = options.tls_options.as_ref().map(|_tls_options| {
-            // let client_config = ClientConfig::b();
-            // client_config
-            //     .dangerous()
-            //     .set_certificate_verifier(Arc::new(NoCertificateVerification));
             let client_config = ClientConfig::builder()
                 .with_safe_defaults()
                 .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
@@ -49,11 +46,9 @@ impl ConnectionStream {
         NoDelay::set_nodelay(&mut stream, true)
             .map_err(|e| GremlinError::Generic(e.to_string()))?;
 
-        let (client, _response) = 
-            // client_tls(request, stream)
+        let (client, _response) =
             client_tls_with_config(options.websocket_url(), stream, None, connector)
-            // client_tls_with_config(request, stream, None, Some(Connector::Rustls(Arc::new(ClientConfig::new()))))
-            .map_err(|e| GremlinError::Generic(e.to_string()))?;
+                .map_err(|e| GremlinError::Generic(e.to_string()))?;
 
         Ok(ConnectionStream(client))
     }
@@ -233,14 +228,6 @@ impl Connection {
         self.broken
     }
 }
-
-// impl TlsOptions {
-//     pub(crate) fn tls_connector(&self) -> native_tls::Result<TlsConnector> {
-//         TlsConnector::builder()
-//             .danger_accept_invalid_certs(self.accept_invalid_certs)
-//             .build()
-//     }
-// }
 
 #[cfg(test)]
 mod tests {

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -113,6 +113,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+mod cert;
 mod client;
 mod connection;
 mod conversion;

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -110,6 +110,9 @@
 //!    })
 //!}
 //!
+#[cfg(all(feature = "tokio-runtime", feature = "async-std-runtime"))]
+compile_error!("features `tokio-runtime` and `async-std-runtime` are mutually exclusive");
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
Supersedes #184 

Closes #176 and #180

Hey there, I started again and successfully trimed native-tls from the dependencies and moved tokio-native-tls to rustls-webpki. All tests pass for async-std and tokio-runtime !

There is still some work to do:
* Adapt Connectors configuration to rustls
* Trim other dependencies
* Rework the features => move async_gremlin to __async_gremlin, to show developers not to use it

I also added a compilation failure if someone tries to use `async-std-runtime` and `tokio-runtime` at the same time.

What do you think of this ?