### PR TITLE
Add .id() step to the traversal builder

### DIFF
--- a/gremlin-client/src/process/traversal/builder.rs
+++ b/gremlin-client/src/process/traversal/builder.rs
@@ -694,4 +694,9 @@ impl TraversalBuilder {
         self.bytecode.add_step(String::from("emit"), vec![]);
         self
     }
+
+    pub fn id(mut self) -> Self {
+        self.bytecode.add_step(String::from("id"), vec![]);
+        self
+    }
 }


### PR DESCRIPTION
Adds the `.id()` step as documented [here](https://tinkerpop.apache.org/docs/current/reference/#id-step).