### PR TITLE
Exposed websocket max_message_size  through ConnectionOptions

### DIFF
--- a/gremlin-client/src/aio/connection.rs
+++ b/gremlin-client/src/aio/connection.rs
@@ -148,9 +148,23 @@ impl Conn {
         let websocket_config = opts.websocket_options.as_ref().map(WebSocketConfig::from);
 
         #[cfg(feature = "async-std-runtime")]
-        let (client, _) = { connect_async_with_tls_connector_and_config(url, tls::connector(&opts), websocket_config).await? };
+        let (client, _) = {
+            connect_async_with_tls_connector_and_config(
+                url,
+                tls::connector(&opts),
+                websocket_config,
+            )
+            .await?
+        };
         #[cfg(feature = "tokio-runtime")]
-        let (client, _) = { connect_async_with_tls_connector_and_config(url, tls::connector(&opts), websocket_config).await? };
+        let (client, _) = {
+            connect_async_with_tls_connector_and_config(
+                url,
+                tls::connector(&opts),
+                websocket_config,
+            )
+            .await?
+        };
 
         let (sink, stream) = client.split();
         let (sender, receiver) = channel(20);

--- a/gremlin-client/src/aio/connection.rs
+++ b/gremlin-client/src/aio/connection.rs
@@ -1,4 +1,4 @@
-use crate::{GremlinError, GremlinResult};
+use crate::{GremlinError, GremlinResult, WebSocketOptions};
 
 use crate::connection::ConnectionOptions;
 
@@ -25,12 +25,12 @@ mod tokio_use {
 use tokio_use::*;
 
 #[cfg(feature = "async-std-runtime")]
-use async_tungstenite::async_std::connect_async_with_tls_connector;
+use async_tungstenite::async_std::connect_async_with_tls_connector_and_config;
 
 #[cfg(feature = "tokio-runtime")]
-use async_tungstenite::tokio::{connect_async_with_tls_connector, TokioAdapter};
+use async_tungstenite::tokio::{connect_async_with_tls_connector_and_config, TokioAdapter};
 
-use async_tungstenite::tungstenite::protocol::Message;
+use async_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
 use async_tungstenite::WebSocketStream;
 use async_tungstenite::{self, stream};
 use futures::{
@@ -110,6 +110,21 @@ mod tls {
     }
 }
 
+impl From<WebSocketOptions> for async_tungstenite::tungstenite::protocol::WebSocketConfig {
+    fn from(value: WebSocketOptions) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&WebSocketOptions> for async_tungstenite::tungstenite::protocol::WebSocketConfig {
+    fn from(value: &WebSocketOptions) -> Self {
+        let mut config = async_tungstenite::tungstenite::protocol::WebSocketConfig::default();
+        config.max_message_size = value.max_message_size;
+        config.max_frame_size = value.max_frame_size;
+        config
+    }
+}
+
 #[cfg(feature = "tokio-runtime")]
 mod tls {
 
@@ -128,12 +143,14 @@ impl Conn {
         T: Into<ConnectionOptions>,
     {
         let opts = options.into();
-        let url = url::Url::parse(&opts.websocket_url()).expect("failed to pars url");
+        let url = url::Url::parse(&opts.websocket_url()).expect("failed to parse url");
+
+        let websocket_config = opts.websocket_options.as_ref().map(WebSocketConfig::from);
 
         #[cfg(feature = "async-std-runtime")]
-        let (client, _) = { connect_async_with_tls_connector(url, tls::connector(&opts)).await? };
+        let (client, _) = { connect_async_with_tls_connector_and_config(url, tls::connector(&opts), websocket_config).await? };
         #[cfg(feature = "tokio-runtime")]
-        let (client, _) = { connect_async_with_tls_connector(url, tls::connector(&opts)).await? };
+        let (client, _) = { connect_async_with_tls_connector_and_config(url, tls::connector(&opts), websocket_config).await? };
 
         let (sink, stream) = client.split();
         let (sender, receiver) = channel(20);

--- a/gremlin-client/src/connection.rs
+++ b/gremlin-client/src/connection.rs
@@ -5,8 +5,9 @@ use native_tls::TlsConnector;
 use tungstenite::{
     client::{uri_mode, IntoClientRequest},
     client_tls_with_config,
+    protocol::WebSocketConfig,
     stream::{MaybeTlsStream, Mode, NoDelay},
-    Connector, Message, WebSocket, protocol::WebSocketConfig,
+    Connector, Message, WebSocket,
 };
 
 struct ConnectionStream(WebSocket<MaybeTlsStream<TcpStream>>);
@@ -47,7 +48,10 @@ impl ConnectionStream {
         NoDelay::set_nodelay(&mut stream, true)
             .map_err(|e| GremlinError::Generic(e.to_string()))?;
 
-        let websocket_config = options.websocket_options.as_ref().map(WebSocketConfig::from);
+        let websocket_config = options
+            .websocket_options
+            .as_ref()
+            .map(WebSocketConfig::from);
 
         let (client, _response) =
             client_tls_with_config(options.websocket_url(), stream, websocket_config, connector)
@@ -201,7 +205,6 @@ impl Default for WebSocketOptions {
         }
     }
 }
-
 
 impl From<WebSocketOptions> for tungstenite::protocol::WebSocketConfig {
     fn from(value: WebSocketOptions) -> Self {

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -122,7 +122,7 @@ mod message;
 mod pool;
 
 pub use client::GremlinClient;
-pub use connection::{ConnectionOptions, ConnectionOptionsBuilder, TlsOptions};
+pub use connection::{ConnectionOptions, ConnectionOptionsBuilder, TlsOptions, WebSocketOptions, WebSocketOptionsBuilder};
 pub use conversion::{BorrowFromGValue, FromGValue, ToGValue};
 pub use error::GremlinError;
 pub use io::GraphSON;

--- a/gremlin-client/src/lib.rs
+++ b/gremlin-client/src/lib.rs
@@ -122,7 +122,10 @@ mod message;
 mod pool;
 
 pub use client::GremlinClient;
-pub use connection::{ConnectionOptions, ConnectionOptionsBuilder, TlsOptions, WebSocketOptions, WebSocketOptionsBuilder};
+pub use connection::{
+    ConnectionOptions, ConnectionOptionsBuilder, TlsOptions, WebSocketOptions,
+    WebSocketOptionsBuilder,
+};
 pub use conversion::{BorrowFromGValue, FromGValue, ToGValue};
 pub use error::GremlinError;
 pub use io::GraphSON;


### PR DESCRIPTION
Hey @wolf4ood I bumped into what seems to be an implicit default that wasn't exposed by this crate. These functions:

https://github.com/wolf4ood/gremlin-rs/blob/master/gremlin-client/src/connection.rs#L51
https://github.com/wolf4ood/gremlin-rs/blob/master/gremlin-client/src/aio/connection.rs#L133-L136

Appeared to be leveraging `tungstenite`'s default websocket settings by using the method that didn't specify a websocket config:

https://github.com/snapview/tungstenite-rs/blob/371f8230444e209cc37ec481e94d621eddf5f0af/src/tls.rs#L180
https://github.com/sdroege/async-tungstenite/blob/2365647978412f47e681d498f25b8469f4355f11/src/tokio.rs#L267

This `None` then becomes the defaults defined by `tungstenite`: https://github.com/snapview/tungstenite-rs/blob/master/src/protocol/mod.rs#L39-L70

I was having I/O issues bumping into these implicit limits. Fwiw they are "supposed" to be configured to the target graph provider's `max_message_size`, and JanusGraph at least sets its default to just 65k, obviously way less than the 64MiB implicitly being used from `tungstenite`.


I tried to mimic prior builders / config patterns, but happy to make any changes.

If accepted & merged mind cutting a new release?