### PR TITLE
Fix From<tungstenite::Error> for non async_gremlin features

### DIFF
--- a/gremlin-client/src/error.rs
+++ b/gremlin-client/src/error.rs
@@ -54,3 +54,17 @@ impl From<mobc::Error<GremlinError>> for GremlinError {
         }
     }
 }
+
+#[cfg(not(feature = "async_gremlin"))]
+impl From<tungstenite::error::Error> for GremlinError {
+    fn from(e: tungstenite::error::Error) -> GremlinError {
+        let error = match e {
+            tungstenite::error::Error::AlreadyClosed => tungstenite::error::Error::AlreadyClosed,
+            tungstenite::error::Error::ConnectionClosed => {
+                tungstenite::error::Error::ConnectionClosed
+            }
+            _ => return GremlinError::Generic(format!("Error from ws {}", e)),
+        };
+        GremlinError::WebSocket(error)
+    }
+}


### PR DESCRIPTION
 Fixes `the trait From<tungstenite::Error> is not implemented for GremlinError` with non async features.
 
 I'm not sure this is the right way to solve the problem. 