### PR TITLE
Expose connection pool's get timeout via ConnectionOptionsBuilder

### DIFF
--- a/gremlin-client/src/aio/client.rs
+++ b/gremlin-client/src/aio/client.rs
@@ -56,7 +56,10 @@ impl GremlinClient {
         let pool_size = opts.pool_size;
         let manager = GremlinConnectionManager::new(opts.clone());
 
-        let pool = Pool::builder().max_open(pool_size as u64).build(manager);
+        let pool = Pool::builder()
+            .get_timeout(opts.pool_get_connection_timeout)
+            .max_open(pool_size as u64)
+            .build(manager);
 
         Ok(GremlinClient {
             pool,

--- a/gremlin-client/src/client.rs
+++ b/gremlin-client/src/client.rs
@@ -54,10 +54,14 @@ impl GremlinClient {
         let pool_size = opts.pool_size;
         let manager = GremlinConnectionManager::new(opts.clone());
 
-        let pool = Pool::builder().max_size(pool_size).build(manager)?;
+        let mut pool_builder = Pool::builder().max_size(pool_size);
+
+        if let Some(get_connection_timeout) = opts.pool_get_connection_timeout {
+            pool_builder = pool_builder.connection_timeout(get_connection_timeout);
+        }
 
         Ok(GremlinClient {
-            pool,
+            pool: pool_builder.build(manager)?,
             session: None,
             alias: None,
             options: opts,

--- a/gremlin-client/src/connection.rs
+++ b/gremlin-client/src/connection.rs
@@ -1,4 +1,4 @@
-use std::net::TcpStream;
+use std::{net::TcpStream, time::Duration};
 
 use crate::{GraphSON, GremlinError, GremlinResult};
 use native_tls::TlsConnector;
@@ -120,6 +120,13 @@ impl ConnectionOptionsBuilder {
         self
     }
 
+    /// Both the sync and async pool providers use a default of 30 seconds,
+    /// Async pool interprets `None` as no timeout. Sync pool maps `None` to the default value
+    pub fn pool_connection_timeout(mut self, pool_connection_timeout: Option<Duration>) -> Self {
+        self.0.pool_get_connection_timeout = pool_connection_timeout;
+        self
+    }
+
     pub fn build(self) -> ConnectionOptions {
         self.0
     }
@@ -163,6 +170,7 @@ pub struct ConnectionOptions {
     pub(crate) host: String,
     pub(crate) port: u16,
     pub(crate) pool_size: u32,
+    pub(crate) pool_get_connection_timeout: Option<Duration>,
     pub(crate) credentials: Option<Credentials>,
     pub(crate) ssl: bool,
     pub(crate) tls_options: Option<TlsOptions>,
@@ -245,6 +253,7 @@ impl Default for ConnectionOptions {
             host: String::from("localhost"),
             port: 8182,
             pool_size: 10,
+            pool_get_connection_timeout: Some(Duration::from_secs(30)),
             credentials: None,
             ssl: false,
             tls_options: None,


### PR DESCRIPTION
I was periodically encountering my applications effectively locking up because of Errors stating `Async pool timeout` . In my use case I'd rather just wait indefinitely for a connection to be available throughout my application. Prior to this PR `gremlin-rs` was relying on the default pool connection timeout of 30 seconds, coincidentally the same for both the sync pool (r2d2) and the async pool (mobc) providers.

This PR will allow users of the library to modify the timeout, and possibly, for the async pool, opt out of a timeout all together.

@wolf4ood jumped to a PR, but happy to open an issue if you'd like to talk & refine the idea further. If it looks good to you as is mind cutting another release once it's merged?