### PR TITLE
Fix direct embedding of json values within decoded data for `GraphSON::V3`.

### DIFF
--- a/gremlin-client/src/io/macros.rs
+++ b/gremlin-client/src/io/macros.rs
@@ -5,6 +5,18 @@ macro_rules! g_serializer {
                 Ok(s.clone().into())
             } else if let Value::Bool(b) = val {
                 Ok((*b).into())
+            } else if let Value::Null = val {
+                Ok(GValue::Null)
+            } else if let Value::Number(ref n) = val {
+                if let Some(i) = n.as_i64() {
+                    Ok(i.into())
+                } else if let Some(f) = n.as_f64() {
+                    Ok(f.into())
+                } else {
+                    Err(GremlinError::Json("Expected number".to_string()))
+                }
+            } else if let Value::Array(ref l) = val {
+                Ok(l.iter().map($name).collect::<GremlinResult<Vec<GValue>>>()?.into())
             } else {
                 let _type = &val["@type"];
                 let _type = get_value!(_type,serde_json::Value::String)?.as_str();

--- a/gremlin-client/src/io/serializer_v3.rs
+++ b/gremlin-client/src/io/serializer_v3.rs
@@ -423,6 +423,7 @@ mod tests {
 
     use super::deserializer_v3;
     use serde_json::json;
+    use serde_json::Value;
 
     use crate::{edge, vertex};
 
@@ -733,5 +734,45 @@ mod tests {
         .collect();
 
         assert_eq!(result, GValue::Map(value_map));
+    }
+
+    #[test]
+    fn test_direct_decode() {
+        let value = json!({
+            "@type": "g:List",
+            "@value": [
+                json!(0.2),
+                json!(0.1),
+            ]
+        });
+
+        let result = deserializer_v3(&value).expect("Failed to deserialize a List");
+
+        assert_eq!(
+            result,
+            GValue::List(vec![GValue::Double(0.2), GValue::Double(0.1)].into())
+        );
+
+        let value = json!({
+            "@type": "g:List",
+            "@value": [
+                Value::Null,
+            ]
+        });
+
+        let result = deserializer_v3(&value).expect("Failed to deserialize a List");
+
+        assert_eq!(result, GValue::List(vec![GValue::Null].into()));
+
+        let value = json!({
+            "@type": "g:List",
+            "@value": [
+                json!(1),
+            ]
+        });
+
+        let result = deserializer_v3(&value).expect("Failed to deserialize a List");
+
+        assert_eq!(result, GValue::List(vec![GValue::Int64(1)].into()));
     }
 }


### PR DESCRIPTION
I have added a test that shows the existing problem when a GraphSON object gets decoded it could have direct `serde_json::Value` objects within it. This will cause a decoding failure as the existing code only checks for `Bool` and `String` directly. I have added checks for `Null`, `Number` and `Array` and the decoding of them into their contained real values.

